### PR TITLE
Disable built-in authentification and CSRF

### DIFF
--- a/backend/src/main/java/com/demo/ecommerce/SecurityConfig.java
+++ b/backend/src/main/java/com/demo/ecommerce/SecurityConfig.java
@@ -1,0 +1,21 @@
+package com.demo.ecommerce;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.annotation.web.configurers.CsrfConfigurer;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+public class SecurityConfig {
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        return http
+                // Disable the auth login since we are going to use JWT
+                .formLogin(AbstractHttpConfigurer::disable)
+                // Not needed in a REST API
+                .csrf(CsrfConfigurer::disable).build();
+    }
+}


### PR DESCRIPTION
Disable built-in authentificacion since we will use JWT tokens on our REST API.
Disable CSRF since it is not useful in REST applications.